### PR TITLE
Update for MoP Classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is voice packs for DBM (Deadly Boss Mods) created by Milho and Daydream (Da
 If there are any suggestions/problems, please contact me.
  
 **How update audio files for DBM (reminder)**
-* check toc format https://wowpedia.fandom.com/wiki/TOC_format
+* check toc format https://warcraft.wiki.gg/wiki/TOC_format
 * generate-new-dico script (ctl F5 ici)
 * Then in G:\Dev\WOW-VoicePack-Generator\dbm-dictionaries
 * translate dummy texts, check version of VPVEM (update DMB Voice version un package and install script)

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -5,7 +5,7 @@ addonversion = "0.3.6"
 DBMVoiceVersion = "18"
 
 Interface = "110107"
-InterfaceMoP = "50500"
+InterfaceMists = "50500"
 InterfaceCata = "40402"
 InterfaceWrath = "30404"
 InterfaceTBC = "20504"
@@ -48,7 +48,7 @@ def install_addon(addon_name:str, version:str):
     key_to_var["INTERFACETBC_KEY"] = InterfaceTBC
     key_to_var["INTERFACEWARTH_KEY"] = InterfaceWrath
     key_to_var["INTERFACECATA_KEY"] = InterfaceCata
-    key_to_var["INTERFACEMOP_KEY"] = InterfaceMoP
+    key_to_var["INTERFACEMISTS_KEY"] = InterfaceMists
     key_to_var["VERSION_KEY"] = version
     key_to_var["DBM_VOICE_KEY"] = DBMVoiceVersion
 

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -4,11 +4,12 @@ from pathlib import Path
 addonversion = "0.3.6"
 DBMVoiceVersion = "18"
 
-Interface = "110007"
-InterfaceCata = "40401"
-InterfaceWrath = "30403"
+Interface = "110107"
+InterfaceMoP = "50500"
+InterfaceCata = "40402"
+InterfaceWrath = "30404"
 InterfaceTBC = "20504"
-InterfaceClassic = "11505"
+InterfaceClassic = "11507"
 
 DIPPKG_PATH = Path("G:\Dev\DBM-VoicePack\zip-files")
 ADDON_path = Path("G:\Dev\DBM-VoicePack")
@@ -44,9 +45,10 @@ def install_addon(addon_name:str, version:str):
     key_to_var = {}
     key_to_var["INTERFACE_KEY"] = Interface
     key_to_var["INTERFACECLASSIC_KEY"] = InterfaceClassic
-    key_to_var["INTERFACEWARTH_KEY"] = InterfaceWrath
     key_to_var["INTERFACETBC_KEY"] = InterfaceTBC
+    key_to_var["INTERFACEWARTH_KEY"] = InterfaceWrath
     key_to_var["INTERFACECATA_KEY"] = InterfaceCata
+    key_to_var["INTERFACEMOP_KEY"] = InterfaceMoP
     key_to_var["VERSION_KEY"] = version
     key_to_var["DBM_VOICE_KEY"] = DBMVoiceVersion
 

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -4,11 +4,12 @@ from pathlib import Path
 addonversion = "0.3.6"
 DBMVoiceVersion = "18"
 
-Interface = "110007"
-InterfaceCata = "40401"
-InterfaceWrath = "30403"
+Interface = "110107"
+InterfaceMoP = "50500"
+InterfaceCata = "40402"
+InterfaceWrath = "30404"
 InterfaceTBC = "20504"
-InterfaceClassic = "11505"
+InterfaceClassic = "11507"
 
 
 
@@ -45,9 +46,10 @@ def package_addon(addon_name:str, version:str):
     key_to_var = {}
     key_to_var["INTERFACE_KEY"] = Interface
     key_to_var["INTERFACECLASSIC_KEY"] = InterfaceClassic
-    key_to_var["INTERFACEWRATH_KEY"] = InterfaceWrath
     key_to_var["INTERFACETBC_KEY"] = InterfaceTBC
+    key_to_var["INTERFACEWARTH_KEY"] = InterfaceWrath
     key_to_var["INTERFACECATA_KEY"] = InterfaceCata
+    key_to_var["INTERFACEMOP_KEY"] = InterfaceMoP
     key_to_var["VERSION_KEY"] = version
     key_to_var["DBM_VOICE_KEY"] = DBMVoiceVersion
 
@@ -63,6 +65,7 @@ def package_addon(addon_name:str, version:str):
     files.append(addon_name+"_Vanilla.toc")
     files.append(addon_name+"_Wrath.toc")
     files.append(addon_name+"_Cata.toc")
+    files.append(addon_name+"_MoP.toc")
     for file in files:
         toc_file = Path(dest / file)
         replace_keys(key_to_var, toc_file)

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -5,7 +5,7 @@ addonversion = "0.3.6"
 DBMVoiceVersion = "18"
 
 Interface = "110107"
-InterfaceMoP = "50500"
+InterfaceMists = "50500"
 InterfaceCata = "40402"
 InterfaceWrath = "30404"
 InterfaceTBC = "20504"
@@ -49,7 +49,7 @@ def package_addon(addon_name:str, version:str):
     key_to_var["INTERFACETBC_KEY"] = InterfaceTBC
     key_to_var["INTERFACEWARTH_KEY"] = InterfaceWrath
     key_to_var["INTERFACECATA_KEY"] = InterfaceCata
-    key_to_var["INTERFACEMOP_KEY"] = InterfaceMoP
+    key_to_var["INTERFACEMISTS_KEY"] = InterfaceMists
     key_to_var["VERSION_KEY"] = version
     key_to_var["DBM_VOICE_KEY"] = DBMVoiceVersion
 
@@ -65,7 +65,7 @@ def package_addon(addon_name:str, version:str):
     files.append(addon_name+"_Vanilla.toc")
     files.append(addon_name+"_Wrath.toc")
     files.append(addon_name+"_Cata.toc")
-    files.append(addon_name+"_MoP.toc")
+    files.append(addon_name+"_Mists.toc")
     for file in files:
         toc_file = Path(dest / file)
         replace_keys(key_to_var, toc_file)


### PR DESCRIPTION
> Note that comma-delimited interface versions or per-file conditional loading directives should be preferred over the use of client-specific TOC files where possible. […]
> [Patch 10.2.7](https://warcraft.wiki.gg/wiki/Patch_10.2.7/API_changes) (2024-05-07): Added support for comma-delimited Interface versions […]
> https://warcraft.wiki.gg/wiki/TOC_format

Maybe keeping multiple .toc files is no longer relevant. Lots of addons have stopped doing this.